### PR TITLE
docs: update credit API examples to v2 endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 docs.json
+docs/

--- a/api-reference/sprinter/credit/build-transaction-calls-to-disable-auto-top-up.mdx
+++ b/api-reference/sprinter/credit/build-transaction-calls-to-disable-auto-top-up.mdx
@@ -1,25 +1,32 @@
 ---
 title: "Disable Auto Top-Up"
 sidebarTitle: "Disable Auto Top-Up"
-openapi: get /credit/accounts/{account}/operator/auto-topup/disable
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/disable
 ---
+
+<Info>
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`.
+</Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/accounts/0xUSER/operator/auto-topup/disable'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/disable?receiver=0xRECEIVER'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/accounts/0xUSER/operator/auto-topup/disable")
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/disable",
+    params={"receiver": "0xRECEIVER"}
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/accounts/0xUSER/operator/auto-topup/disable"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/disable?receiver=0xRECEIVER"
 );
 const data = await response.json();
 console.log(data);
@@ -35,7 +42,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/accounts/0xUSER/operator/auto-topup/disable")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/disable?receiver=0xRECEIVER")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/build-transaction-calls-to-draw-credit.mdx
+++ b/api-reference/sprinter/credit/build-transaction-calls-to-draw-credit.mdx
@@ -1,29 +1,32 @@
 ---
 title: "Draw Credit"
 sidebarTitle: "Draw Credit"
-openapi: get /credit/accounts/{account}/draw
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/draw
 ---
 
 <Info>
-A **0.50% origination fee** is deducted from each draw. See [Fees](/sprinter-credit/credit-engine#fees) for details.
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`. A **0.50% origination fee** is deducted from each draw. See [Fees](/sprinter-credit/credit-engine#fees) for details.
 </Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/accounts/{account}/draw'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/draw?amount=1000000&receiver=0xRECEIVER'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/accounts/{account}/draw")
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/draw",
+    params={"amount": "1000000", "receiver": "0xRECEIVER"}
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/accounts/{account}/draw"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/draw?amount=1000000&receiver=0xRECEIVER"
 );
 const data = await response.json();
 console.log(data);
@@ -39,7 +42,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/accounts/{account}/draw")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/draw?amount=1000000&receiver=0xRECEIVER")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/call-data-to-repay-credit-debt.mdx
+++ b/api-reference/sprinter/credit/call-data-to-repay-credit-debt.mdx
@@ -1,29 +1,32 @@
 ---
 title: "Repay Debt"
 sidebarTitle: "Repay Debt"
-openapi: get /credit/accounts/{account}/repay
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/repay
 ---
 
 <Info>
-Repay before the due date to avoid the **15% overdue APR**. See [Fees](/sprinter-credit/credit-engine#fees) for details.
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`. Repay before the due date to avoid the **15% overdue APR**. See [Fees](/sprinter-credit/credit-engine#fees) for details.
 </Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/accounts/{account}/repay'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/repay?amount=1000000'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/accounts/{account}/repay")
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/repay",
+    params={"amount": "1000000"}
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/accounts/{account}/repay"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/repay?amount=1000000"
 );
 const data = await response.json();
 console.log(data);
@@ -39,7 +42,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/accounts/{account}/repay")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/repay?amount=1000000")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/call-data-to-unlock-collateral.mdx
+++ b/api-reference/sprinter/credit/call-data-to-unlock-collateral.mdx
@@ -1,25 +1,32 @@
 ---
 title: "Unlock Collateral"
 sidebarTitle: "Unlock Collateral"
-openapi: get /credit/accounts/{account}/unlock
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/unlock
 ---
+
+<Info>
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`. The `collateral` query parameter is the collateral asset address to unlock.
+</Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/accounts/{account}/unlock'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/unlock?amount=1000000&collateral=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/accounts/{account}/unlock")
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/unlock",
+    params={"amount": "1000000", "collateral": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"}
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/accounts/{account}/unlock"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/unlock?amount=1000000&collateral=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
 );
 const data = await response.json();
 console.log(data);
@@ -35,7 +42,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/accounts/{account}/unlock")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/unlock?amount=1000000&collateral=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/calldata-to-lock-asset-as-collateral.mdx
+++ b/api-reference/sprinter/credit/calldata-to-lock-asset-as-collateral.mdx
@@ -1,25 +1,32 @@
 ---
 title: "Lock Collateral"
 sidebarTitle: "Lock Collateral"
-openapi: get /credit/accounts/{account}/lock
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/lock
 ---
+
+<Info>
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`. The `earnAsset` query parameter is the collateral asset address (underlying token like USDC, or an earn position like gtUSDCp).
+</Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/accounts/{account}/lock'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/lock?amount=1000000&earnAsset=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/accounts/{account}/lock")
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/lock",
+    params={"amount": "1000000", "earnAsset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"}
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/accounts/{account}/lock"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/lock?amount=1000000&earnAsset=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
 );
 const data = await response.json();
 console.log(data);
@@ -35,7 +42,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/accounts/{account}/lock")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/lock?amount=1000000&earnAsset=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/claim-position-from-earn-vault.mdx
+++ b/api-reference/sprinter/credit/claim-position-from-earn-vault.mdx
@@ -11,19 +11,28 @@ The `chain` parameter uses **CAIP-2 format**: `eip155:<chainId>`. For example, `
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/earn/claim'
+  --url 'https://api.sprinter.tech/credit/earn/claim?owner=0xUSER&receiver=0xRECEIVER&asset=0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61&chain=eip155:8453&claimRequestId=0'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/earn/claim")
+response = requests.get(
+    "https://api.sprinter.tech/credit/earn/claim",
+    params={
+        "owner": "0xUSER",
+        "receiver": "0xRECEIVER",
+        "asset": "0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61",
+        "chain": "eip155:8453",
+        "claimRequestId": "0"
+    }
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/earn/claim"
+  "https://api.sprinter.tech/credit/earn/claim?owner=0xUSER&receiver=0xRECEIVER&asset=0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61&chain=eip155:8453&claimRequestId=0"
 );
 const data = await response.json();
 console.log(data);
@@ -39,7 +48,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/earn/claim")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/earn/claim?owner=0xUSER&receiver=0xRECEIVER&asset=0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61&chain=eip155:8453&claimRequestId=0")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/get-auto-topup-config.mdx
+++ b/api-reference/sprinter/credit/get-auto-topup-config.mdx
@@ -1,0 +1,67 @@
+---
+title: "Get Auto Top-Up Config"
+sidebarTitle: "Get Auto Top-Up Config"
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/config
+---
+
+<Info>
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`.
+</Info>
+
+<RequestExample>
+```bash cURL
+curl --request GET \
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/config?receiver=0xRECEIVER'
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/config",
+    params={"receiver": "0xRECEIVER"}
+)
+print(response.json())
+```
+
+```javascript JavaScript
+const response = await fetch(
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/config?receiver=0xRECEIVER"
+);
+const data = await response.json();
+console.log(data);
+```
+
+```go Go
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func main() {
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/config?receiver=0xRECEIVER")
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	fmt.Println(string(body))
+}
+```
+</RequestExample>
+
+<ResponseExample>
+```json 200
+{
+  "config": {
+    "threshold": "500000000",
+    "targetBalance": "1000000000",
+    "healthFactor": "10000"
+  }
+}
+```
+</ResponseExample>
+
+<Tip>
+**Machine-readable API spec:** [OpenAPI JSON](https://api.sprinter.tech/swagger/doc.json) | [Swagger UI](https://api.sprinter.tech/swagger/index.html)
+</Tip>

--- a/api-reference/sprinter/credit/get-collateral-asset-details.mdx
+++ b/api-reference/sprinter/credit/get-collateral-asset-details.mdx
@@ -1,29 +1,31 @@
 ---
 title: "Collateral Details"
 sidebarTitle: "Collateral Details"
-openapi: get /credit/collateral/{chain}/{collateral}
+openapi: get /credit/v2/assets/{asset}/collateral/{chain}/{collateral}
 ---
 
 <Info>
-The `chain` parameter uses **CAIP-2 format**: `eip155:<chainId>`. For example, `eip155:8453` for Base or `eip155:1` for Ethereum. See [Supported Chains](/sprinter-credit/overview#supported-chains) for the full list.
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`. The `chain` parameter uses **CAIP-2 format**: `eip155:<chainId>`. For example, `eip155:8453` for Base or `eip155:1` for Ethereum. See [Supported Chains](/sprinter-credit/overview#supported-chains) for the full list.
 </Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/collateral/{chain}/{collateral}'
+  --url 'https://api.sprinter.tech/credit/v2/assets/usdc/collateral/eip155:8453/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/collateral/{chain}/{collateral}")
+response = requests.get(
+    "https://api.sprinter.tech/credit/v2/assets/usdc/collateral/eip155:8453/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/collateral/{chain}/{collateral}"
+  "https://api.sprinter.tech/credit/v2/assets/usdc/collateral/eip155:8453/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
 );
 const data = await response.json();
 console.log(data);
@@ -39,7 +41,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/collateral/{chain}/{collateral}")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/assets/usdc/collateral/eip155:8453/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))
@@ -50,12 +52,11 @@ func main() {
 <ResponseExample>
 ```json 200
 {
-  "collateralAddress": "0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61",
-  "collateralPriceUsd": 1.023456,
-  "earnServiceName": "Gauntlet",
-  "isEarnVault": true,
-  "apy": 4.56,
-  "underlyingAsset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "collateralAddress": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "collateralPriceUsd": 1.0,
+  "earnServiceName": "",
+  "isEarnVault": false,
+  "underlyingAsset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
   "underlyingPriceUsd": 1.0
 }
 ```

--- a/api-reference/sprinter/credit/get-operator-status-for-an-account.mdx
+++ b/api-reference/sprinter/credit/get-operator-status-for-an-account.mdx
@@ -1,25 +1,29 @@
 ---
 title: "Operator Status"
 sidebarTitle: "Operator Status"
-openapi: get /credit/accounts/{account}/operator
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/operator
 ---
+
+<Info>
+The `asset` parameter is the credit asset symbol — currently supported values are `usdc` and `eure`.
+</Info>
 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/accounts/0xUSER/operator'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/accounts/0xUSER/operator")
+response = requests.get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator")
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/accounts/0xUSER/operator"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator"
 );
 const data = await response.json();
 console.log(data);
@@ -35,7 +39,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/accounts/0xUSER/operator")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/overview.mdx
+++ b/api-reference/sprinter/credit/overview.mdx
@@ -30,27 +30,27 @@ Point your AI agent or code generator at the [OpenAPI spec](https://api.sprinter
 |----------|-------------|
 | [`GET /credit/protocol`](/api-reference/sprinter/credit/get-credit-protocol-configuration) | Protocol configuration — supported chains, collateral assets, LTV ratios, earn strategies |
 | [`GET /credit/accounts/{account}/info`](/api-reference/sprinter/credit/get-user-credit-information) | Account credit position — capacity, debt, health factor |
-| [`GET /credit/accounts/{account}/collateral`](/api-reference/sprinter/credit/get-collateral-asset-details) | Collateral asset details |
-| [`GET /credit/accounts/{account}/operator`](/api-reference/sprinter/credit/get-operator-status-for-an-account) | Operator status for delegated draws |
+| [`GET /credit/v2/assets/{asset}/collateral/{chain}/{collateral}`](/api-reference/sprinter/credit/get-collateral-asset-details) | Collateral asset details |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/operator`](/api-reference/sprinter/credit/get-operator-status-for-an-account) | Operator status for delegated draws |
 
 ### Actions
 
 | Endpoint | Description |
 |----------|-------------|
-| [`GET /credit/accounts/{account}/lock`](/api-reference/sprinter/credit/calldata-to-lock-asset-as-collateral) | Build calldata to lock collateral |
-| [`GET /credit/accounts/{account}/unlock`](/api-reference/sprinter/credit/call-data-to-unlock-collateral) | Build calldata to unlock collateral |
-| [`GET /credit/accounts/{account}/draw`](/api-reference/sprinter/credit/build-transaction-calls-to-draw-credit) | Build calldata to draw (borrow) credit |
-| [`GET /credit/accounts/{account}/repay`](/api-reference/sprinter/credit/call-data-to-repay-credit-debt) | Build calldata to repay debt |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/lock`](/api-reference/sprinter/credit/calldata-to-lock-asset-as-collateral) | Build calldata to lock collateral |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/unlock`](/api-reference/sprinter/credit/call-data-to-unlock-collateral) | Build calldata to unlock collateral |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/draw`](/api-reference/sprinter/credit/build-transaction-calls-to-draw-credit) | Build calldata to draw (borrow) credit |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/repay`](/api-reference/sprinter/credit/call-data-to-repay-credit-debt) | Build calldata to repay debt |
 
 ### Advanced
 
 | Endpoint | Description |
 |----------|-------------|
-| [`GET /credit/accounts/{account}/auto-top-up/enable`](/api-reference/sprinter/credit/build-transaction-calls-to-enable-auto-top-up) | Enable auto top-up |
-| [`GET /credit/accounts/{account}/auto-top-up/disable`](/api-reference/sprinter/credit/build-transaction-calls-to-disable-auto-top-up) | Disable auto top-up |
-| [`GET /credit/accounts/{account}/wrap`](/api-reference/sprinter/credit/wrap-asset-into-earn-vault) | Wrap asset into earn vault |
-| [`GET /credit/accounts/{account}/unwrap`](/api-reference/sprinter/credit/unwrap-position-from-earn-vault) | Unwrap from earn vault |
-| [`GET /credit/accounts/{account}/claim`](/api-reference/sprinter/credit/claim-position-from-earn-vault) | Claim position from earn vault |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/enable`](/api-reference/sprinter/credit/build-transaction-calls-to-enable-auto-top-up) | Enable auto top-up |
+| [`GET /credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/disable`](/api-reference/sprinter/credit/build-transaction-calls-to-disable-auto-top-up) | Disable auto top-up |
+| [`GET /credit/earn/wrap`](/api-reference/sprinter/credit/wrap-asset-into-earn-vault) | Wrap asset into earn vault |
+| [`GET /credit/earn/unwrap`](/api-reference/sprinter/credit/unwrap-position-from-earn-vault) | Unwrap from earn vault |
+| [`GET /credit/earn/claim`](/api-reference/sprinter/credit/claim-position-from-earn-vault) | Claim position from earn vault |
 
 ## Response Format
 

--- a/api-reference/sprinter/credit/unwrap-position-from-earn-vault.mdx
+++ b/api-reference/sprinter/credit/unwrap-position-from-earn-vault.mdx
@@ -11,19 +11,28 @@ The `chain` parameter uses **CAIP-2 format**: `eip155:<chainId>`. For example, `
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/earn/unwrap'
+  --url 'https://api.sprinter.tech/credit/earn/unwrap?owner=0xUSER&receiver=0xRECEIVER&amount=1000000&asset=0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61&chain=eip155:8453'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/earn/unwrap")
+response = requests.get(
+    "https://api.sprinter.tech/credit/earn/unwrap",
+    params={
+        "owner": "0xUSER",
+        "receiver": "0xRECEIVER",
+        "amount": "1000000",
+        "asset": "0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61",
+        "chain": "eip155:8453"
+    }
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/earn/unwrap"
+  "https://api.sprinter.tech/credit/earn/unwrap?owner=0xUSER&receiver=0xRECEIVER&amount=1000000&asset=0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61&chain=eip155:8453"
 );
 const data = await response.json();
 console.log(data);
@@ -39,7 +48,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/earn/unwrap")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/earn/unwrap?owner=0xUSER&receiver=0xRECEIVER&amount=1000000&asset=0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61&chain=eip155:8453")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/update-auto-top-up.mdx
+++ b/api-reference/sprinter/credit/update-auto-top-up.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Enable Auto Top-Up"
-sidebarTitle: "Enable Auto Top-Up"
-openapi: get /credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/enable
+title: "Update Auto Top-Up"
+sidebarTitle: "Update Auto Top-Up"
+openapi: get /credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/update
 ---
 
 <Info>
@@ -11,14 +11,14 @@ The `asset` parameter is the credit asset symbol — currently supported values 
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/enable?receiver=0xRECEIVER&threshold=500000000&targetBalance=1000000000'
+  --url 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/update?receiver=0xRECEIVER&threshold=500000000&targetBalance=1000000000'
 ```
 
 ```python Python
 import requests
 
 response = requests.get(
-    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/enable",
+    "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/update",
     params={"receiver": "0xRECEIVER", "threshold": "500000000", "targetBalance": "1000000000"}
 )
 print(response.json())
@@ -26,7 +26,7 @@ print(response.json())
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/enable?receiver=0xRECEIVER&threshold=500000000&targetBalance=1000000000"
+  "https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/update?receiver=0xRECEIVER&threshold=500000000&targetBalance=1000000000"
 );
 const data = await response.json();
 console.log(data);
@@ -42,7 +42,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/enable?receiver=0xRECEIVER&threshold=500000000&targetBalance=1000000000")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/operator/auto-topup/update?receiver=0xRECEIVER&threshold=500000000&targetBalance=1000000000")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/credit/wrap-asset-into-earn-vault.mdx
+++ b/api-reference/sprinter/credit/wrap-asset-into-earn-vault.mdx
@@ -11,19 +11,28 @@ The `chain` parameter uses **CAIP-2 format**: `eip155:<chainId>`. For example, `
 <RequestExample>
 ```bash cURL
 curl --request GET \
-  --url 'https://api.sprinter.tech/credit/earn/wrap'
+  --url 'https://api.sprinter.tech/credit/earn/wrap?owner=0xUSER&amount=1000000&asset=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913&chain=eip155:8453&earn=gauntlet-usdc-prime'
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.sprinter.tech/credit/earn/wrap")
+response = requests.get(
+    "https://api.sprinter.tech/credit/earn/wrap",
+    params={
+        "owner": "0xUSER",
+        "amount": "1000000",
+        "asset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "chain": "eip155:8453",
+        "earn": "gauntlet-usdc-prime"
+    }
+)
 print(response.json())
 ```
 
 ```javascript JavaScript
 const response = await fetch(
-  "https://api.sprinter.tech/credit/earn/wrap"
+  "https://api.sprinter.tech/credit/earn/wrap?owner=0xUSER&amount=1000000&asset=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913&chain=eip155:8453&earn=gauntlet-usdc-prime"
 );
 const data = await response.json();
 console.log(data);
@@ -39,7 +48,7 @@ import (
 )
 
 func main() {
-	resp, _ := http.Get("https://api.sprinter.tech/credit/earn/wrap")
+	resp, _ := http.Get("https://api.sprinter.tech/credit/earn/wrap?owner=0xUSER&amount=1000000&asset=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913&chain=eip155:8453&earn=gauntlet-usdc-prime")
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	fmt.Println(string(body))

--- a/api-reference/sprinter/openapi.json
+++ b/api-reference/sprinter/openapi.json
@@ -1504,6 +1504,800 @@
                     }
                 }
             }
+        },
+        "/credit/v2/assets/{asset}/collateral/{chain}/{collateral}": {
+            "get": {
+                "description": "Returns detailed information about a collateral asset including APY estimate (if earn vault), price in USD, underlying asset, and earn service name",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Get collateral asset details",
+                "parameters": [
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "eip155:8453",
+                        "description": "Chain ID in CAIP-2 format",
+                        "name": "chain",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61",
+                        "description": "Collateral asset address",
+                        "name": "collateral",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/credit.CollateralDetailsResponse"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Collateral not supported",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/operator": {
+            "get": {
+                "description": "Returns the current operator address and list of whitelisted credit receivers.",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Get operator status for an account",
+                "parameters": [
+                    {
+                        "description": "User account address",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Operator status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.GetOperatorStatus.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/lock": {
+            "get": {
+                "description": "Creates list of contract calls to lock assets as collateral for credit account. Supports both underlying assets (e.g., USDC) which are wrapped into earn vault first, and earn positions (e.g., gtUSDCp) which are deposited directly.",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Calldata to lock asset as collateral",
+                "parameters": [
+                    {
+                        "description": "Account that holds the asset and will execute calls",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Amount in lowest denomination (e.g., wei for ETH)",
+                        "name": "amount",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Asset address in eth format - either underlying asset (USDC) or earn position (gtUSDCp)",
+                        "name": "earnAsset",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Earn strategy to wrap asset before depositing. If omitted, asset is deposited directly without wrapping.",
+                        "name": "earn",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of contract calls to execute locking of collateral",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.Lock.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request due to invalid input or missing parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/unlock": {
+            "get": {
+                "description": "Creates list of contract calls to unlock and withdraw\ncollateral and potentially unwrap position from earn vault",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Call data to unlock collateral",
+                "parameters": [
+                    {
+                        "description": "Account that holds the asset and will execute calls",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Amount in lowest denomination (e.g., wei for ETH)",
+                        "name": "amount",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Asset address in eth format",
+                        "name": "collateral",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Whether to generate call to unwrap from earn strategy",
+                        "name": "unwrap",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of contract calls to execute unlocking of collateral",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.Unlock.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request due to invalid input or missing parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/draw": {
+            "get": {
+                "description": "Returns the calls needed to draw credit. If the user has sufficient\nregistered collateral, the drawCredit call is returned.",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Build transaction calls to draw credit",
+                "parameters": [
+                    {
+                        "description": "User account address (borrower)",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Amount to borrow (in wei)",
+                        "name": "amount",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Address to receive the borrowed funds",
+                        "name": "receiver",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of contract calls to execute drawing credit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.DrawCredit.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request due to invalid input or insufficient collateral",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/repay": {
+            "get": {
+                "description": "Creates list of contract calls to approve USDC and repay debt to CreditHub",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Call data to repay credit debt",
+                "parameters": [
+                    {
+                        "description": "Account (borrower) that will repay the debt",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Amount in lowest denomination (e.g., wei for ETH)",
+                        "name": "amount",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of contract calls to execute repayment",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.Repay.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request due to invalid input or missing parameters",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/enable": {
+            "get": {
+                "description": "Returns the calls needed to enable auto top-up. Checks on-chain state\nand only includes setOperator (if not already set) and addCreditReceiver\n(if not already whitelisted).",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Build transaction calls to enable auto top-up",
+                "parameters": [
+                    {
+                        "description": "User account address",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Asset symbol to auto top-up (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Receiver address to auto top-up",
+                        "name": "receiver",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of contract calls",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.GetEnableAutoTopup.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Account has a different operator",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/disable": {
+            "get": {
+                "description": "Returns the removeCreditReceiver call if the receiver is currently\nwhitelisted; returns empty calls if already disabled.",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Build transaction calls to disable auto top-up",
+                "parameters": [
+                    {
+                        "description": "User account address",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Receiver address to remove",
+                        "name": "receiver",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of contract calls",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.GetDisableAutoTopup.response"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/responses.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/config": {
+            "get": {
+                "description": "Returns the current auto top-up configuration for a given receiver.",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Get auto top-up config",
+                "parameters": [
+                    {
+                        "description": "User account address",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Receiver address to get config for",
+                        "name": "receiver",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Auto top-up configuration",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "config"
+                                    ],
+                                    "properties": {
+                                        "config": {
+                                            "type": "object",
+                                            "required": [
+                                                "threshold",
+                                                "targetBalance",
+                                                "healthFactor"
+                                            ],
+                                            "properties": {
+                                                "threshold": {
+                                                    "type": "string",
+                                                    "example": "500000000"
+                                                },
+                                                "targetBalance": {
+                                                    "type": "string",
+                                                    "example": "1000000000"
+                                                },
+                                                "healthFactor": {
+                                                    "type": "string",
+                                                    "example": "10000"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/credit/v2/accounts/{account}/assets/{asset}/operator/auto-topup/update": {
+            "get": {
+                "description": "Builds calldata to update an existing auto top-up configuration.",
+                "tags": [
+                    "Credit"
+                ],
+                "summary": "Update auto top-up config",
+                "parameters": [
+                    {
+                        "description": "User account address",
+                        "name": "account",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "example": "usdc",
+                        "description": "Credit asset symbol (e.g. usdc, eure)",
+                        "name": "asset",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Receiver address whose config is being updated",
+                        "name": "receiver",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "New balance threshold that triggers top-up (in wei)",
+                        "name": "threshold",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "New target balance after top-up (in wei, must be >= threshold)",
+                        "name": "targetBalance",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Minimum health factor in basis points (10000 = 1.0)",
+                        "name": "healthFactor",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Calldata to update auto top-up",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/credit.callsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/mint.json
+++ b/mint.json
@@ -103,6 +103,8 @@
           "pages": [
             "api-reference/sprinter/credit/build-transaction-calls-to-enable-auto-top-up",
             "api-reference/sprinter/credit/build-transaction-calls-to-disable-auto-top-up",
+            "api-reference/sprinter/credit/get-auto-topup-config",
+            "api-reference/sprinter/credit/update-auto-top-up",
             "api-reference/sprinter/credit/wrap-asset-into-earn-vault",
             "api-reference/sprinter/credit/unwrap-position-from-earn-vault",
             "api-reference/sprinter/credit/claim-position-from-earn-vault"


### PR DESCRIPTION
Updated credit API documentation to match v2 approach. 
Update some new parameters naming to match current requests. 