### PR TITLE
docs: add yoUSDC, yoBTC collateral and yo strategies to supported assets

### DIFF
--- a/sprinter-credit/supported-assets.mdx
+++ b/sprinter-credit/supported-assets.mdx
@@ -15,11 +15,11 @@ Collateral can be locked to open an overcollateralized credit line. Each asset h
 
 | Asset | Symbol | Chain | LTV | Maintenance LTV | Collateral Tier |
 |---|---|---|:---:|:---:|---|
-| USDC | `USDC` | Base | 90% | 94% | Raw stablecoin |
-| Gauntlet USDC Prime | `gtUSDCp` | Base | 75% | 82% | Stable vault |
-| Superform USDC | `superUSDC` | Base | 70% | — | USDC SuperVault |
-| yoUSDC | `yoUSD` | Base | 70% | — | Stable vault |
-| yoBTC | `yoBTC` | Base | 55% | — | Volatile vault |
+| USDC | `USDC` | Base | 90% | 92.5% | Raw stablecoin |
+| Gauntlet USDC Prime | `gtUSDCp` | Base | 75% | 80% | Stable vault |
+| Superform USDC | `superUSDC` | Base | 70% | 75% | USDC SuperVault |
+| yoUSDC | `yoUSD` | Base | 70% | 80% | Stable vault |
+| yoBTC | `yoBTC` | Base | 55% | 70% | Volatile vault |
 
 <Info>
 LTV values are returned by the API as basis points (e.g. `9000` = 90%). A `null` LTV means the asset is accepted as collateral but parameters are being finalized.
@@ -31,9 +31,10 @@ All supported collateral falls into one of these tiers. LTV and maintenance thre
 
 | Tier | Examples | LTV | Maintenance LTV | Liquidation Bonus |
 |---|---|:---:|:---:|:---:|
-| Raw stablecoin | USDC | 90% | 94% | 5% |
-| Stable vault | Gauntlet USDC Prime | 75% | 82% | 5% |
-| USDC SuperVault | Superform USDC | 85% | 90% | 6% |
+| Raw stablecoin | USDC | 90% | 92.5% | 1% |
+| Stable vault | gtUSDCp, yoUSDC | 75% | 80% | 6% |
+| USDC SuperVault | superUSDC | 70% | 75% | 6% |
+| Volatile vault | yoBTC | 55% | 70% | 8% |
 | Raw volatile | ETH, WBTC | 80% | 85% | 5% |
 | Volatile DEX-swap | stETH, cbETH | 75% | 82% | 5% |
 | Volatile vault | yoETH | 65% | 75% | 6% |

--- a/sprinter-credit/supported-assets.mdx
+++ b/sprinter-credit/supported-assets.mdx
@@ -17,7 +17,9 @@ Collateral can be locked to open an overcollateralized credit line. Each asset h
 |---|---|---|:---:|:---:|---|
 | USDC | `USDC` | Base | 90% | 94% | Raw stablecoin |
 | Gauntlet USDC Prime | `gtUSDCp` | Base | 75% | 82% | Stable vault |
-| Superform USDC | `superUSDC` | Base | — | — | USDC SuperVault |
+| Superform USDC | `superUSDC` | Base | 70% | — | USDC SuperVault |
+| yoUSDC | `yoUSD` | Base | 70% | — | Stable vault |
+| yoBTC | `yoBTC` | Base | 55% | — | Volatile vault |
 
 <Info>
 LTV values are returned by the API as basis points (e.g. `9000` = 90%). A `null` LTV means the asset is accepted as collateral but parameters are being finalized.
@@ -50,11 +52,13 @@ Earn strategies allow collateral to generate yield while it backs a credit line.
 |---|---|---|---|---|---|---|:---:|
 | `gauntlet-usdc-prime` | Gauntlet USDC Prime | Morpho V1 | Gauntlet | USDC | Base | ERC-4626 | 5 |
 | `superform-usdc` | superUSDC | Superform | Superform | USDC | Base | ERC-7540 | 7 |
+| `yo-usdc` | yoUSDC | Yo Protocol | Yo | USDC | Base | ERC-7540 | 5 |
+| `yo-btc` | yoBTC | Yo Protocol | Yo | BTC | Base | ERC-7540 | 5 |
 
 Use the strategy ID as the `earn` parameter when locking collateral:
 
 ```bash
-curl -X GET 'https://api.sprinter.tech/credit/accounts/0xUSER/lock?amount=1000000000&asset=0xCOLLATERAL&earn=gauntlet-usdc-prime'
+curl -X GET 'https://api.sprinter.tech/credit/v2/accounts/0xUSER/assets/usdc/lock?amount=1000000000&earnAsset=0xCOLLATERAL&earn=gauntlet-usdc-prime'
 ```
 
 <Info>


### PR DESCRIPTION
Adds yoUSDC and yoBTC as live collateral assets, yo-usdc and yo-btc earn strategies to match current prod API, fixes superUSDC LTV from — to 70%, and updates the lock example to the v2 endpoint with the renamed earnAsset parameter.