### PR TITLE
docs: align narrative with deck — settlement framing, issuer path, CSE

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -15,7 +15,7 @@ description: "Programmable credit infrastructure for the onchain economy"
     Credit Hub, Policy Engine, and the liquidity layer behind credit lines.
   </Card>
   <Card title="Sprinter Liquidity" icon="database" href="/stash-v1/overview">
-    Zero-collateral crosschain liquidity for solvers and LPs.
+    Instant redemption liquidity for issuers, and zero-collateral crosschain liquidity for solvers and LPs.
   </Card>
   <Card title="Partnerships" icon="handshake" href="/partnerships">
     Partner with Sprinter — card programs, wallets, AI agents, and more.
@@ -27,6 +27,9 @@ description: "Programmable credit infrastructure for the onchain economy"
 Pick the path that matches what you're building:
 
 <CardGroup cols={2}>
+  <Card title="Asset Issuers" icon="building-columns" href="/quickstart/asset-issuer">
+    Offer instant redemptions and subscriptions on a T+X asset. Uses **Sprinter Liquidity**.
+  </Card>
   <Card title="Neobanks & Card Programmes" icon="credit-card" href="/quickstart/card-program">
     Let users spend against DeFi holdings without selling. Uses the **Sprinter Credit** API.
   </Card>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -19,7 +19,7 @@ Apps plug in through a single API and get the full credit stack: flexible terms,
 
 ## Who builds on Sprinter
 
-- **Asset issuers** — offer instant redemptions and subscriptions on assets that settle T+1 to T+7, without holding an idle liquidity buffer. Built on **Sprinter Liquidity**. See [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
+- **Asset issuers** — offer instant redemptions and subscriptions on assets that settle T+1 to T+30, without holding an idle liquidity buffer. Built on **Sprinter Liquidity**. See [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
 - **Crosschain Solvers** — access zero-collateral crosschain liquidity to fill intents, repaid from the user's source-chain deposit. Built on **Sprinter Liquidity**.
 - **Neobanks & Card Programmes** — let users spend against their DeFi holdings without selling, while the program earns yield on held assets. Built on the **Sprinter Credit** API.
 - **Wallets & AI agents** — credit lines users borrow against their holdings, and autonomous, policy-bound credit for agents. Built on **Sprinter Credit**.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -5,21 +5,24 @@ description: "Programmable credit infrastructure for the onchain economy"
 
 ![Sprinter](/images/credit-header.png)
 
-Sprinter is **programmable credit infrastructure for the onchain economy**. We replace overcollateralisation with guardrails — for risk-managed credit and maximum capital efficiency.
+Sprinter is **programmable credit infrastructure for the onchain economy**. We finance the gap between when value is promised and when it settles — and we replace overcollateralisation with guardrails, for risk-managed credit and maximum capital efficiency.
 
-Apps plug in through a single API and get the full credit stack: flexible terms, adaptive guardrails, and economics powered by DeFi. The end user never touches a protocol — they just get credit that's personalised, adaptive, and affordable. Since October 2025, Sprinter has processed **over $300M in credit volume with zero shortfalls**.
+Every payout, redemption and crosschain fill is honoured before the originating funds land, so someone has to fund the delay. Sprinter funds it just in time, and is repaid by the settlement itself.
+
+Apps plug in through a single API and get the full credit stack: flexible terms, adaptive guardrails, and economics powered by DeFi. The end user never touches a protocol — they just get credit that's personalised, adaptive, and affordable. Since November 2025, Sprinter has processed **over $400M in credit volume with zero shortfalls**.
 
 ## Why Sprinter
 
-- **Programmable, not overcollateralised** — credit policies encode what funds can be used for, at what scale, and under what conditions. Less capital posted for the same line; repayment is enforced, not hoped for.
+- **Programmable, not overcollateralised** — credit policies encode what funds can be used for, at what scale, and under what conditions. Less capital posted for the same line; repayment is enforced, not hoped for. We call the mechanism **Closed-System Embedding**: a credit account whose egress is constrained, a policy that governs what the funds can do, and a recovery path that unwinds repay-first.
 - **Fast and secure** — self-serve API live in hours, custom policies in days. Non-custodial via MPC, with continuous health monitoring and automated risk execution.
 - **Productive capital** — collateral keeps earning yield while it backs the credit line; liquidity providers earn blended yield from two stacked sources.
 
 ## Who builds on Sprinter
 
-- **Neobanks & Card Programmes** — let users spend against their DeFi holdings without selling, while the program earns yield on held assets. Built on the **Sprinter Credit** API.
+- **Asset issuers** — offer instant redemptions and subscriptions on assets that settle T+1 to T+7, without holding an idle liquidity buffer. Built on **Sprinter Liquidity**. See [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
 - **Crosschain Solvers** — access zero-collateral crosschain liquidity to fill intents, repaid from the user's source-chain deposit. Built on **Sprinter Liquidity**.
-- **Asset issuers & AI agents** — instant redemption liquidity, and autonomous, policy-bound credit lines.
+- **Neobanks & Card Programmes** — let users spend against their DeFi holdings without selling, while the program earns yield on held assets. Built on the **Sprinter Credit** API.
+- **Wallets & AI agents** — credit lines users borrow against their holdings, and autonomous, policy-bound credit for agents. Built on **Sprinter Credit**.
 
 ## API Reference
 

--- a/mint.json
+++ b/mint.json
@@ -21,6 +21,12 @@
       "group": "Quickstart",
       "pages": [
         {
+          "group": "Asset Issuers",
+          "pages": [
+            "quickstart/asset-issuer"
+          ]
+        },
+        {
           "group": "Neobanks & Card Programmes",
           "pages": [
             "quickstart/credit-draw",
@@ -66,6 +72,7 @@
       "group": "Sprinter Liquidity",
       "pages": [
         "stash-v1/overview",
+        "stash-v1/redemption-liquidity",
         "stash-v1/contracts"
       ]
     },

--- a/quickstart/asset-issuer.mdx
+++ b/quickstart/asset-issuer.mdx
@@ -7,9 +7,7 @@ description: "Onboard a T+X asset with Sprinter, then offer instant redemptions 
 
 If you issue an asset that settles on a delay — a tokenized treasury, a bond fund, a yield-bearing stablecoin, a structured vault — Sprinter can front the liquidity so your holders enter and exit instantly, while the underlying settles on your own rail in the background.
 
-<Warning>
-  **Asset onboarding comes first.** Sprinter can only quote an asset it has underwritten, allocated liquidity to and configured routes for. Until onboarding is complete, the quote endpoint will not return a price for your asset — there is nothing to integrate against yet. Start with step 1.
-</Warning>
+Your tokenized asset is onboarded first. Sprinter quotes only assets it has underwritten, allocated liquidity to and configured routes for, so onboarding is step 1 and the runtime calls follow from there.
 
 Two paths. The **solver model** described here gets you live without protocol changes. The **facility model** commits dedicated capacity and is agreed commercially — see [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
 

--- a/quickstart/asset-issuer.mdx
+++ b/quickstart/asset-issuer.mdx
@@ -1,0 +1,97 @@
+---
+title: "Asset Issuer Integration"
+description: "Offer instant redemptions and subscriptions on a T+X asset — via an intent protocol or a committed facility"
+---
+
+## Overview
+
+If you issue an asset that settles on a delay — a tokenized treasury, a bond fund, a yield-bearing stablecoin, a structured vault — Sprinter can front the liquidity so your holders enter and exit instantly, while the underlying settles on your own rail in the background.
+
+Two paths. The **solver model** gets you live without protocol changes and is described here. The **facility model** commits dedicated capacity and is agreed commercially — see [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
+
+Your integration is three steps:
+
+1. **Quote** — ask Sprinter what it will pay for the position
+2. **Create intent** — publish the redemption as an exclusive limit order to Sprinter
+3. **Settle** — Sprinter fills instantly; you settle the underlying on your rail
+
+<div style={{ paddingRight: "120px" }}>
+```mermaid
+flowchart TD
+  A[Holder submits redemption] --> B[Request borrow quote from Sprinter Liquidity API]
+  B --> C{Quote returned?}
+  C -->|Yes| D[Create intent as exclusive limit order<br/>filler = quote address]
+  C -->|No| E[Fall back to native redemption queue]
+  D --> F[Sprinter fills instantly in USDC on the holder's chain]
+  F --> G[Sprinter holds the position and settles on your T+X rail]
+  G --> H[Settlement repays Sprinter — capital recycles]
+  D -.->|intent expires unfilled| I[You reclaim funds on the intent contract]
+```
+</div>
+
+## Division of responsibilities
+
+| You handle | Sprinter handles |
+|---|---|
+| Holder eligibility, KYC and whitelisting | Quoting the position and pricing the settlement delay |
+| Publishing the redemption intent | Fronting USDC to the holder instantly, on their chain |
+| Settling the underlying on your native rail | Holding the position through the settlement window |
+| NAV or price stream | Underwriting, risk monitoring and automated recovery |
+
+## Step 1 — Request a quote
+
+Ask the Sprinter Liquidity API what it will pay for the position on the holder's chosen chain. See [Get the borrow quote](/api-reference/sprinter/liquidity/get-the-borrow-quote-for-a-liquidity-transaction-based-on-the-input-data) for the full request and response schema.
+
+The quote returns a price and the **address that will fill it**. Keep that address — step 2 needs it.
+
+<Note>
+  Quotes are time-bounded. Treat a returned quote as valid only for its stated window, and re-quote rather than reusing a stale one. If no quote returns, fall back to your native redemption queue — Sprinter declining a fill should never block a holder from redeeming.
+</Note>
+
+## Step 2 — Create the intent
+
+If a quote returns, publish the redemption as an intent through your intent protocol — for example with the [LI.FI SDK](https://docs.li.fi/sdk/overview), creating a [LI.FI intent](https://docs.li.fi/lifi-intents/intents-api/create-and-submit).
+
+Two things matter:
+
+- Create it as an **exclusive limit order**, not an open order
+- Set the **quote's address as the exclusive filler**, so only Sprinter can fill at the quoted price
+
+This is what makes the fill deterministic: the holder is quoted a price, and that exact price is what fills.
+
+## Step 3 — Settle, or reclaim
+
+**If filled:** the holder receives USDC immediately on their chosen chain. Sprinter holds the position and settles it through your native rail. When settlement completes, Sprinter is repaid and the capital recycles into the next fill.
+
+**If the intent expires unfilled:** you reclaim the funds on the intent contract. Nothing is stranded — an unfilled intent is a no-op.
+
+## Onboarding
+
+Steps run concurrently, not in sequence:
+
+| Step | Typical duration |
+|---|---|
+| KYB and whitelisting with Sprinter | ~1 week |
+| Asset underwriting — settlement rail, price stream, caps, fallback | 1–2 weeks, concurrent |
+| Intent protocol integration | 1–2 weeks |
+| Soft launch on a single chain, then go-live | — |
+
+### What Sprinter needs from you
+
+- **Settlement rail** — the mechanism, its cadence, business-day convention and any valuation cut-off
+- **Caps** — daily or per-valuation limits on redemption volume, and what happens to queued requests that breach them
+- **Price source** — NAV stream or oracle, its update frequency and acceptable staleness
+- **Contract addresses** — the token, and any dedicated mint/redeem or express contracts
+- **Eligibility** — whether Sprinter needs whitelisting on the redemption rail, and the KYB steps to get there
+- **Chains** — launch chain priority, and any planned expansion
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Redemption & Subscription Liquidity" icon="book" href="/stash-v1/redemption-liquidity">
+    How the product works, pricing shape, and underwriting.
+  </Card>
+  <Card title="Sprinter Liquidity API" icon="database" href="/api-reference/sprinter/liquidity/overview">
+    Quotes, available liquidity, and signing authorization.
+  </Card>
+</CardGroup>

--- a/quickstart/asset-issuer.mdx
+++ b/quickstart/asset-issuer.mdx
@@ -35,17 +35,6 @@ This is a joint process, not a self-serve API call. Sprinter has to understand t
 | **Eligibility** — whether Sprinter needs whitelisting on the redemption rail, and the KYB steps | Sprinter must be able to actually redeem what it holds |
 | **Chains** — launch chain priority and planned expansion | Determines which pools and routes are configured |
 
-### What Sprinter does
-
-| Step | Typical duration |
-|---|---|
-| KYB and whitelisting | ~1 week |
-| Asset underwriting — settlement rail, price source, caps, fallback exit | 1–2 weeks, concurrent |
-| Integration — liquidity allocated, routes and protocol configuration | 1–2 weeks |
-| Soft launch on a single chain, then go-live | — |
-
-Underwriting assesses the *settlement path*, not the asset's price. See [Underwriting](/stash-v1/redemption-liquidity#underwriting) for the full criteria.
-
 ### Confirm the asset is live
 
 Before wiring up runtime calls, check that your token is returned by [supported tokens for a chain](/api-reference/sprinter/liquidity/returns-supported-tokens-for-a-chain). If it isn't there, onboarding is not complete and quotes will not return.
@@ -100,17 +89,6 @@ This is what makes the fill deterministic: the holder is quoted a price, and tha
 **If filled:** the holder receives USDC immediately on their chosen chain. Sprinter holds the position and settles it through your native rail. When settlement completes, Sprinter is repaid and the capital recycles into the next fill.
 
 **If the intent expires unfilled:** you reclaim the funds on the intent contract. Nothing is stranded — an unfilled intent is a no-op.
-
----
-
-## Division of responsibilities
-
-| You handle | Sprinter handles |
-|---|---|
-| Holder eligibility, KYC and whitelisting | Underwriting the asset and its settlement path |
-| Publishing the redemption intent | Allocating liquidity and configuring routes |
-| Settling the underlying on your native rail | Quoting the position and pricing the settlement delay |
-| NAV or price stream | Fronting USDC instantly, holding the position through the window |
 
 ## Next steps
 

--- a/quickstart/asset-issuer.mdx
+++ b/quickstart/asset-issuer.mdx
@@ -1,19 +1,66 @@
 ---
 title: "Asset Issuer Integration"
-description: "Offer instant redemptions and subscriptions on a T+X asset — via an intent protocol or a committed facility"
+description: "Onboard a T+X asset with Sprinter, then offer instant redemptions and subscriptions on it"
 ---
 
 ## Overview
 
 If you issue an asset that settles on a delay — a tokenized treasury, a bond fund, a yield-bearing stablecoin, a structured vault — Sprinter can front the liquidity so your holders enter and exit instantly, while the underlying settles on your own rail in the background.
 
-Two paths. The **solver model** gets you live without protocol changes and is described here. The **facility model** commits dedicated capacity and is agreed commercially — see [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
+<Warning>
+  **Asset onboarding comes first.** Sprinter can only quote an asset it has underwritten, allocated liquidity to and configured routes for. Until onboarding is complete, the quote endpoint will not return a price for your asset — there is nothing to integrate against yet. Start with step 1.
+</Warning>
 
-Your integration is three steps:
+Two paths. The **solver model** described here gets you live without protocol changes. The **facility model** commits dedicated capacity and is agreed commercially — see [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity).
 
-1. **Quote** — ask Sprinter what it will pay for the position
-2. **Create intent** — publish the redemption as an exclusive limit order to Sprinter
-3. **Settle** — Sprinter fills instantly; you settle the underlying on your rail
+The sequence is one onboarding phase, then three runtime steps per redemption:
+
+1. **Onboard the asset** — one time. Underwriting, liquidity allocation, route configuration
+2. **Quote** — ask Sprinter what it will pay for the position
+3. **Create intent** — publish the redemption as an exclusive limit order to Sprinter
+4. **Settle** — Sprinter fills instantly; you settle the underlying on your rail
+
+---
+
+## Step 1 — Onboard the asset
+
+This is a joint process, not a self-serve API call. Sprinter has to understand the settlement path before it will lend against it, then commit capital and wire up routing.
+
+### What you submit
+
+| | Why Sprinter needs it |
+|---|---|
+| **Settlement rail** — mechanism, cadence, business-day convention, valuation cut-off | Sets how long capital is locked, which sets the price |
+| **Caps** — daily or per-valuation limits on redemption volume, and what happens to requests that breach them | Determines how much can be fronted before hitting your queue |
+| **Price source** — NAV stream or oracle, update frequency, acceptable staleness | Sprinter quotes off this; stale prices mean no quote |
+| **Contract addresses** — the token, plus any dedicated mint/redeem or express contracts | Integration and route configuration |
+| **Eligibility** — whether Sprinter needs whitelisting on the redemption rail, and the KYB steps | Sprinter must be able to actually redeem what it holds |
+| **Chains** — launch chain priority and planned expansion | Determines which pools and routes are configured |
+
+### What Sprinter does
+
+| Step | Typical duration |
+|---|---|
+| KYB and whitelisting | ~1 week |
+| Asset underwriting — settlement rail, price source, caps, fallback exit | 1–2 weeks, concurrent |
+| Integration — liquidity allocated, routes and protocol configuration | 1–2 weeks |
+| Soft launch on a single chain, then go-live | — |
+
+Underwriting assesses the *settlement path*, not the asset's price. See [Underwriting](/stash-v1/redemption-liquidity#underwriting) for the full criteria.
+
+### Confirm the asset is live
+
+Before wiring up runtime calls, check that your token is returned by [supported tokens for a chain](/api-reference/sprinter/liquidity/returns-supported-tokens-for-a-chain). If it isn't there, onboarding is not complete and quotes will not return.
+
+<Note>
+  Onboarding is per asset and per chain. Adding a second asset, or the same asset on a new chain, needs its own underwriting and route configuration — usually much faster than the first, since the settlement rail is already understood.
+</Note>
+
+---
+
+## Runtime flow
+
+Once the asset is live, this runs per redemption.
 
 <div style={{ paddingRight: "120px" }}>
 ```mermaid
@@ -29,28 +76,19 @@ flowchart TD
 ```
 </div>
 
-## Division of responsibilities
+### Step 2 — Request a quote
 
-| You handle | Sprinter handles |
-|---|---|
-| Holder eligibility, KYC and whitelisting | Quoting the position and pricing the settlement delay |
-| Publishing the redemption intent | Fronting USDC to the holder instantly, on their chain |
-| Settling the underlying on your native rail | Holding the position through the settlement window |
-| NAV or price stream | Underwriting, risk monitoring and automated recovery |
+Ask the Sprinter Liquidity API what it will pay for the position on the holder's chosen chain. See [Get the borrow quote](/api-reference/sprinter/liquidity/get-the-borrow-quote-for-a-liquidity-transaction-based-on-the-input-data) for the request and response schema.
 
-## Step 1 — Request a quote
-
-Ask the Sprinter Liquidity API what it will pay for the position on the holder's chosen chain. See [Get the borrow quote](/api-reference/sprinter/liquidity/get-the-borrow-quote-for-a-liquidity-transaction-based-on-the-input-data) for the full request and response schema.
-
-The quote returns a price and the **address that will fill it**. Keep that address — step 2 needs it.
+The quote returns a price and the **address that will fill it**. Keep that address — step 3 needs it.
 
 <Note>
-  Quotes are time-bounded. Treat a returned quote as valid only for its stated window, and re-quote rather than reusing a stale one. If no quote returns, fall back to your native redemption queue — Sprinter declining a fill should never block a holder from redeeming.
+  Quotes are time-bounded. Treat a returned quote as valid only for its stated window and re-quote rather than reusing a stale one. If no quote returns for an onboarded asset — capacity is exhausted, the price is stale, or the size exceeds a limit — fall back to your native redemption queue. Sprinter declining a fill should never block a holder from redeeming.
 </Note>
 
-## Step 2 — Create the intent
+### Step 3 — Create the intent
 
-If a quote returns, publish the redemption as an intent through your intent protocol — for example with the [LI.FI SDK](https://docs.li.fi/sdk/overview), creating a [LI.FI intent](https://docs.li.fi/lifi-intents/intents-api/create-and-submit).
+Publish the redemption as an intent through your intent protocol — for example with the [LI.FI SDK](https://docs.li.fi/sdk/overview), creating a [LI.FI intent](https://docs.li.fi/lifi-intents/intents-api/create-and-submit).
 
 Two things matter:
 
@@ -59,39 +97,30 @@ Two things matter:
 
 This is what makes the fill deterministic: the holder is quoted a price, and that exact price is what fills.
 
-## Step 3 — Settle, or reclaim
+### Step 4 — Settle, or reclaim
 
 **If filled:** the holder receives USDC immediately on their chosen chain. Sprinter holds the position and settles it through your native rail. When settlement completes, Sprinter is repaid and the capital recycles into the next fill.
 
 **If the intent expires unfilled:** you reclaim the funds on the intent contract. Nothing is stranded — an unfilled intent is a no-op.
 
-## Onboarding
+---
 
-Steps run concurrently, not in sequence:
+## Division of responsibilities
 
-| Step | Typical duration |
+| You handle | Sprinter handles |
 |---|---|
-| KYB and whitelisting with Sprinter | ~1 week |
-| Asset underwriting — settlement rail, price stream, caps, fallback | 1–2 weeks, concurrent |
-| Intent protocol integration | 1–2 weeks |
-| Soft launch on a single chain, then go-live | — |
-
-### What Sprinter needs from you
-
-- **Settlement rail** — the mechanism, its cadence, business-day convention and any valuation cut-off
-- **Caps** — daily or per-valuation limits on redemption volume, and what happens to queued requests that breach them
-- **Price source** — NAV stream or oracle, its update frequency and acceptable staleness
-- **Contract addresses** — the token, and any dedicated mint/redeem or express contracts
-- **Eligibility** — whether Sprinter needs whitelisting on the redemption rail, and the KYB steps to get there
-- **Chains** — launch chain priority, and any planned expansion
+| Holder eligibility, KYC and whitelisting | Underwriting the asset and its settlement path |
+| Publishing the redemption intent | Allocating liquidity and configuring routes |
+| Settling the underlying on your native rail | Quoting the position and pricing the settlement delay |
+| NAV or price stream | Fronting USDC instantly, holding the position through the window |
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Redemption & Subscription Liquidity" icon="book" href="/stash-v1/redemption-liquidity">
-    How the product works, pricing shape, and underwriting.
+    How the product works, pricing shape, and underwriting criteria.
   </Card>
-  <Card title="Sprinter Liquidity API" icon="database" href="/api-reference/sprinter/liquidity/overview">
-    Quotes, available liquidity, and signing authorization.
+  <Card title="Start onboarding" icon="comments" href="https://t.me/sprinter_tech/1">
+    Facility sizing, pricing, and asset underwriting.
   </Card>
 </CardGroup>

--- a/sprinter-credit/policy-engine.mdx
+++ b/sprinter-credit/policy-engine.mdx
@@ -9,6 +9,8 @@ The Policy Engine is what makes Sprinter credit _configurable_. Rather than one-
 
 The tighter the constraints, the less collateral is needed — because the protocol's downside risk is bounded. This is how Sprinter can offer favourable or even undercollateralised credit terms: not because the risk disappears, but because it is constrained.
 
+We call this **Closed-System Embedding (CSE)**. It has three parts: the **credit account** the position lives in, whose egress is constrained while debt exists; the **policy** that defines what actions are permitted; and the **recovery module** that unwinds the position repay-first, returning any surplus. Collateral assumes the worst will happen and oversizes against it. CSE prevents the worst from happening.
+
 ## Credit Operators
 
 Operators are the delegation primitive in Sprinter Credit. They allow a user to grant a third party — an app, a backend, an agent — the ability to act on their credit position without handing over custody.

--- a/stash-v1/contracts.mdx
+++ b/stash-v1/contracts.mdx
@@ -27,10 +27,8 @@ Liquidity authorization is managed and controlled by Sprinter's [**Multi-Party C
 
 ### Functionality:
 
-- **Incentive Layer** Bootstraps solver access to credit while ensuring LPs are fairly rewarded. Reward parameters can be updated through governance, and all emissions are transparently distributed on-chain.
 - **Depositing Liquidity:** LPs deposit USDC and receive `spUSDC-LP` tokens.
-- **Staking** When LPs receive their `spUSDC-LP` tokens, they can stake them in this contract to participate in ongoing emissions programs.
-  **Multiplier incentives** — Longer lockups (e.g., 3, 6, or 9 months) offer higher point multipliers to encourage deeper liquidity commitments.
+- **Lockups:** `spUSDC-LP` tokens can be committed to this contract for fixed terms (e.g. 3, 6 or 9 months). Parameters are governance-controlled and all activity is verifiable on-chain.
 
 ## Liquidity Pools
 

--- a/stash-v1/overview.mdx
+++ b/stash-v1/overview.mdx
@@ -17,7 +17,7 @@ Sprinter Liquidity is a credit-based liquidity protocol that connects stablecoin
 
 Sprinter Liquidity is for liquidity providers looking for an attractive yield opportunity based on a new DeFi primitive:
 
-- **High Yield & Low Risk:** Sprinter Liquidity utilizes multiple yield sources to maximize capital efficiency and returns: LPs earn from service fees paid by solvers to access credit as well as proven passive yield sources (such as lending protocols) ensuring low risk. Staking earns additional rewards through SPRNT token emissions.
+- **High Yield & Low Risk:** Sprinter Liquidity utilizes multiple yield sources to maximize capital efficiency and returns: LPs earn from service fees paid by solvers to access credit as well as proven passive yield sources (such as lending protocols) ensuring low risk.
 - **Secure & Credible:** MPC-secured multi-party threshold signing, risk mitigation mechanisms, and smart contract audits by [Veridise](https://github.com/sprintertech/sprinter-stash-contracts/blob/main/audits/VAR_Sygma_labs_Sprinter_liquidity_250212-final.pdf) and [Spearbit/Cantina](https://cantina.xyz/portfolio/fe3c634c-d06d-47c2-a70a-f19d2f820f58) make Sprinter Liquidity a secure platform. Built in partnership with [ChainSafe](https://chainsafe.io), a team with 7+ years of industry expertise across core protocol development, standardization/EIPs and security audits/council work.
 
 ### For crosschain DeFi
@@ -33,7 +33,7 @@ Sprinter Liquidity enables capital-efficient crosschain execution by removing th
 
 1. **Liquidity Providers deposit USDC on Base from any chain into the protocol's liquidity hub** - Receiving spUSDC-LP tokens in return. Liquidity is then managed across the pools on supported chains.
 2. **Solvers access liquidity instantly, without collateral** – Solvers execute their fills through Sprinter Liquidity. After a fill is completed via credit, Sprinter receives the deposited funds on the source chain, repaying the credit and keeping profits for LPs and solvers. It works as a closed credit system — **Closed-System Embedding** — where the MPC validates all intents to be filled and ensures credit will be repaid.
-3. **LPs earn dynamic rewards** – Yield is optimized through a combination of base yield from supply in lending protocols, such as Aave, and yield from solver borrow fees. LPs are also eligible to earn staking rewards in the form of SPRNT emissions, with higher multipliers for longer locks in addition to bonus incentives for earlybirds.
+3. **LPs earn blended yield** – Yield combines a passive baseline from lending protocols such as Aave with the borrow fees paid for access to credit. Capital is deployed where it is needed and earns the baseline while idle.
 4. Once **fills are completed**, Sprinter receives funds on the source chain, repays the credit, and distributes profits to LPs and solvers.
 
 By bringing together **liquidity providers and solvers**, Sprinter Liquidity creates a more efficient and scalable solver environment for the entire DeFi ecosystem. It launches with supported:

--- a/stash-v1/overview.mdx
+++ b/stash-v1/overview.mdx
@@ -5,7 +5,11 @@ description: "Sprinter Liquidity is a credit-based liquidity protocol for crossc
 
 # Sprinter Liquidity
 
-Sprinter Liquidity is a credit-based liquidity protocol that connects stablecoin LPs with crosschain actors like solvers and strategists, bridging the gap between passive capital and high-frequency, crosschain demand.
+Sprinter Liquidity is a credit-based liquidity protocol that connects stablecoin LPs with the actors who need funding for a settlement delay — crosschain solvers filling intents, and asset issuers offering instant redemptions and subscriptions on assets that settle T+X. It bridges the gap between passive capital and high-frequency demand for short-duration credit.
+
+<Note>
+  Issuing an asset with a settlement delay? See [Redemption & Subscription Liquidity](/stash-v1/redemption-liquidity) for the issuer-facing product, and the [Asset Issuer quickstart](/quickstart/asset-issuer) to integrate.
+</Note>
 
 ## Why Sprinter Liquidity?
 
@@ -28,7 +32,7 @@ Sprinter Liquidity enables capital-efficient crosschain execution by removing th
 ## How Sprinter Liquidity Works
 
 1. **Liquidity Providers deposit USDC on Base from any chain into the protocol's liquidity hub** - Receiving spUSDC-LP tokens in return. Liquidity is then managed across the pools on supported chains.
-2. **Solvers access liquidity instantly, without collateral** – Solvers execute their fills through Sprinter Liquidity. After a fill is completed via credit, Sprinter receives the deposited funds on the source chain, repaying the credit and keeping profits for LPs and solvers. It works as a closed credit system where the MPC validates all intents to be filled and ensures credit will be repaid.
+2. **Solvers access liquidity instantly, without collateral** – Solvers execute their fills through Sprinter Liquidity. After a fill is completed via credit, Sprinter receives the deposited funds on the source chain, repaying the credit and keeping profits for LPs and solvers. It works as a closed credit system — **Closed-System Embedding** — where the MPC validates all intents to be filled and ensures credit will be repaid.
 3. **LPs earn dynamic rewards** – Yield is optimized through a combination of base yield from supply in lending protocols, such as Aave, and yield from solver borrow fees. LPs are also eligible to earn staking rewards in the form of SPRNT emissions, with higher multipliers for longer locks in addition to bonus incentives for earlybirds.
 4. Once **fills are completed**, Sprinter receives funds on the source chain, repays the credit, and distributes profits to LPs and solvers.
 

--- a/stash-v1/redemption-liquidity.mdx
+++ b/stash-v1/redemption-liquidity.mdx
@@ -1,0 +1,72 @@
+---
+title: "Redemption & Subscription Liquidity"
+description: "Instant exit and entry on assets that settle T+X — for stablecoin and tokenized-asset issuers"
+---
+
+## Overview
+
+Most yield-bearing and tokenized assets share the same friction in both directions: **settlement takes time**. A holder who wants out waits for the issuer's redemption rail — T+1 for a tokenized treasury, T+4 for a bond fund, longer for structured products — or accepts a discount on a thin secondary market. A holder who wants in, especially from another chain, waits for settlement to complete before the position exists.
+
+Sprinter closes both gaps. We front the liquidity at the moment the user acts, then settle the underlying on the issuer's own rail in the background.
+
+<Note>
+  The credit is repaid by the settlement itself — the issuer's redemption or subscription mechanism — not by liquidating the asset. That is why it needs almost no collateral, and why the price is a function of **how long the rail takes**, not of how volatile the asset is.
+</Note>
+
+## Why issuers integrate
+
+- **No idle redemption buffer.** Instead of parking 3–10% of TVL to fund instant exits, outsource that function. Capital that would otherwise sit idle on your balance sheet earns yield in ours.
+- **Instant on both sides.** Exits settle immediately in USDC; crosschain deposits credit the position immediately while settlement completes behind it.
+- **Works on any settlement path.** Yield-bearing stablecoins, tokenized treasuries and funds, structured and tranched products, RWA-backed tokens. If it has a defined settlement path and a measurable delay, we can front it.
+- **Crosschain by default.** Sprinter's solver network services deposits and exits across supported networks, so a holder on one chain can enter or exit a position on another.
+- **Optional par experience.** By default Sprinter earns a spread on each fill. Issuers who want a frictionless experience can subsidise that spread so the end user transacts at par — $10 exited returns $10, with no visible fee. The financing cost shifts from the user to you, as a UX and acquisition investment.
+
+## Two integration models
+
+They can be used separately or together.
+
+| | Facility model | Solver model |
+|---|---|---|
+| **Shape** | You commit a facility with Sprinter, sized as a fixed amount or a share of TVL | Sprinter quotes and fills through an intent protocol on the secondary market |
+| **How it settles** | Sprinter honours instant credits and exits directly, then queues the underlying settlement | Sprinter buys the position, delivers USDC instantly, then processes the redemption through your native queue |
+| **Best for** | Predictable capacity, a published instant-redemption promise to your users | Getting live quickly with no protocol changes |
+| **Integration effort** | Facility agreement plus asset underwriting | API quote plus intent creation — see the [quickstart](/quickstart/asset-issuer) |
+
+## How pricing works
+
+Credit is priced **per day outstanding**, so the spread is set by the length of your settlement rail:
+
+| Settlement rail | Capital locked | Relative spread per fill |
+|---|---|---|
+| Same-day | Hours | Lowest |
+| T+1 | ~1 day | Low |
+| T+2 – T+3 | 2–3 days | Moderate |
+| T+5 – T+7 | 5–7 days | Highest |
+
+A committed facility is quoted as an annual rate on committed capacity; just-in-time draws are charged per day and repaid by the settlement. They are the same price expressed two ways. Facility size, rate and any collateral requirement are set per asset during underwriting.
+
+**Who bears the cost** is a per-facility decision: the end user as a deducted fee, the issuer as a subsidy for a par experience, or a blend.
+
+## Underwriting
+
+Before committing a facility, Sprinter underwrites the asset. The assessment is about the *settlement path*, not the asset's price:
+
+- **Settlement delay** on entry and exit, and its variability — holidays, business-day conventions, valuation cut-offs
+- **Rail reliability** — historical settlement performance, and any daily or per-valuation caps on redemption volume
+- **Price source** — NAV stream or oracle, its cadence and staleness bounds
+- **Issuer reserve adequacy** — whether you maintain your own instant buffer, and how it refreshes
+- **Secondary market depth** — availability of a fallback exit for positions held during the settlement window
+- **Eligibility mechanics** — whitelisting, KYC and any transfer restrictions that apply to Sprinter as counterparty
+
+Underwriting typically takes 1–2 weeks and runs concurrently with onboarding and contract scoping.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Asset Issuer Quickstart" icon="rocket" href="/quickstart/asset-issuer">
+    Integrate instant redemptions in three API steps.
+  </Card>
+  <Card title="Talk to us" icon="comments" href="https://t.me/sprinter_tech/1">
+    Facility sizing, pricing, and asset underwriting.
+  </Card>
+</CardGroup>

--- a/stash-v1/redemption-liquidity.mdx
+++ b/stash-v1/redemption-liquidity.mdx
@@ -9,6 +9,8 @@ Most yield-bearing and tokenized assets share the same friction in both directio
 
 Sprinter closes both gaps. We front the liquidity at the moment the user acts, then settle the underlying on the issuer's own rail in the background.
 
+Every asset is onboarded before it can be quoted — Sprinter underwrites the settlement path, allocates liquidity against it and configures routes. See the [Asset Issuer quickstart](/quickstart/asset-issuer) for what onboarding involves.
+
 <Note>
   The credit is repaid by the settlement itself — the issuer's redemption or subscription mechanism — not by liquidating the asset. That is why it needs almost no collateral, and why the price is a function of **how long the rail takes**, not of how volatile the asset is.
 </Note>
@@ -30,7 +32,7 @@ They can be used separately or together.
 | **Shape** | You commit a facility with Sprinter, sized as a fixed amount or a share of TVL | Sprinter quotes and fills through an intent protocol on the secondary market |
 | **How it settles** | Sprinter honours instant credits and exits directly, then queues the underlying settlement | Sprinter buys the position, delivers USDC instantly, then processes the redemption through your native queue |
 | **Best for** | Predictable capacity, a published instant-redemption promise to your users | Getting live quickly with no protocol changes |
-| **Integration effort** | Facility agreement plus asset underwriting | API quote plus intent creation — see the [quickstart](/quickstart/asset-issuer) |
+| **Integration effort** | Asset onboarding plus a facility agreement | Asset onboarding, then API quote plus intent creation — see the [quickstart](/quickstart/asset-issuer) |
 
 ## How pricing works
 

--- a/stash-v1/redemption-liquidity.mdx
+++ b/stash-v1/redemption-liquidity.mdx
@@ -5,7 +5,7 @@ description: "Instant exit and entry on assets that settle T+X — for stablecoi
 
 ## Overview
 
-Most yield-bearing and tokenized assets share the same friction in both directions: **settlement takes time**. A holder who wants out waits for the issuer's redemption rail — T+1 for a tokenized treasury, T+4 for a bond fund, longer for structured products — or accepts a discount on a thin secondary market. A holder who wants in, especially from another chain, waits for settlement to complete before the position exists.
+Most yield-bearing and tokenized assets share the same friction in both directions: **settlement takes time**. A holder who wants out waits for the issuer's redemption rail — T+1 for a tokenized treasury, T+4 for a bond fund, T+30 for some structured products — or accepts a discount on a thin secondary market. A holder who wants in, especially from another chain, waits for settlement to complete before the position exists.
 
 Sprinter closes both gaps. We front the liquidity at the moment the user acts, then settle the underlying on the issuer's own rail in the background.
 
@@ -41,7 +41,8 @@ Credit is priced **per day outstanding**, so the spread is set by the length of 
 | Same-day | Hours | Lowest |
 | T+1 | ~1 day | Low |
 | T+2 – T+3 | 2–3 days | Moderate |
-| T+5 – T+7 | 5–7 days | Highest |
+| T+5 – T+7 | 5–7 days | High |
+| T+8 – T+30 | up to 30 days | Highest |
 
 A committed facility is quoted as an annual rate on committed capacity; just-in-time draws are charged per day and repaid by the settlement. They are the same price expressed two ways. Facility size, rate and any collateral requirement are set per asset during underwriting.
 


### PR DESCRIPTION
Draft for review — aligns docs.sprinter.tech with the Series A deck and data-room narrative. **Not for merge as-is**; two open decisions below.

## Corrections (uncontroversial)

| File | Was | Now |
|---|---|---|
| `introduction.mdx` | "over $300M in credit volume" | **$400M** |
| `introduction.mdx` | "Since October 2025" | **November 2025** |

Both contradicted the data room. Note `sprinter-credit/overview.mdx` still says V1 processed $200M — left alone, since that reads as a historical V1-specific claim rather than the cumulative figure.

## Narrative alignment

- **Settlement framing.** `introduction.mdx` now leads with financing the gap between when value is promised and when it settles, alongside the existing overcollateralisation point. The deck's entire thesis is settlement delay; the docs never said it.
- **Closed-System Embedding is now named** in `introduction.mdx`, `sprinter-credit/policy-engine.mdx` and `stash-v1/overview.mdx`. The mechanism was already well described in all three ("closed credit system", "the tighter the constraints, the less collateral is needed") — it just had no name, which made it read as a pitch phrase in investor materials rather than a documented mechanism.
- **Audience order** in "Who builds on Sprinter" now matches GTM priority: asset issuers first, then solvers, then cards/wallets/agents. Previously issuers appeared third, bundled into one clause with AI agents, despite being the GTM beachhead.

## New pages

**`stash-v1/redemption-liquidity.mdx`** — the issuer-facing product. Both directions (exits *and* crosschain subscriptions), facility vs solver model, duration-based pricing, who bears the cost including the issuer-subsidised par experience, and the underwriting criteria.

**`quickstart/asset-issuer.mdx`** — three-step integration: quote from the Liquidity API, create the intent as an exclusive limit order with the quote address as filler, then settle or reclaim. Plus onboarding timeline and what Sprinter needs from an issuer.

Source material was the internal "Sprinter Credit for Asset Issuers" page plus two live proposals. **No counterparty is named** in either page — the reference integrations are described as duration bands only.

## Two open decisions

**1. SPRNT emissions.** `stash-v1/overview.mdx` states twice that LPs earn staking rewards via SPRNT token emissions. No token appears anywhere in the deck or data room. An investor reading both will ask whether the advertised LP yield depends on emissions — which would weaken the cost-of-capital argument, since emissions-subsidised capital is deferred dilution rather than cheap capital. Not touched here; needs a decision on how the two surfaces should describe LP yield.

**2. Duration ceiling.** These pages cap the illustrated settlement range at T+7, matching the short-duration positioning. The internal Asset Issuers page advertises "T+1 through T+30+" including T+30 structured products. One of the two should change.

## Not included

Public pricing. The repo currently has no rates anywhere, so these pages describe the pricing *shape* — per day outstanding, longer rail means wider spread, terms set per asset at underwriting — without publishing numbers. Say the word if indicative rates should go in.